### PR TITLE
Sorted, self-updating views for IntervalDict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## Not yet released
+
+### Added
+ - `IntervalDict.as_dict()` to export its content to a classical Python `dict`.
+
+
 ## 2.0.2 (2020-05-09)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
  - `IntervalDict.as_dict()` to export its content to a classical Python `dict`.
 
 
+## Fixed
+ - `IntervalDict.popitem()` now returns a (key, value) pair instead of an `IntervalDict`.
+ - The documentation of `IntervalDict.pop()` now correctly states that the value (and not the key)
+ is returned.
+
+
+
 ## 2.0.2 (2020-05-09)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
 
-## Not yet released
+## 2.1.0 (not yet released)
 
 ### Added
  - `IntervalDict.as_dict()` to export its content to a classical Python `dict`.
 
+## Changed
+ - `IntervalDict.keys()`, `values()` and `items()` return view objects instead of lists.
 
 ## Fixed
  - `IntervalDict.popitem()` now returns a (key, value) pair instead of an `IntervalDict`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The `portion` library (formerly distributed as `python-intervals`) provides data
  - Heavily tested with high code coverage.
 
 **Latest release:**
- - `portion`: 2.0.2 on 2020-05-09 ([documentation](https://github.com/AlexandreDecan/portion/blob/2.0.2/README.md), [changes](https://github.com/AlexandreDecan/portion/blob/2.0.2/CHANGELOG.md)).
+ - `portion`: 2.1.0 on 2020-05-09 ([documentation](https://github.com/AlexandreDecan/portion/blob/2.1.0/README.md), [changes](https://github.com/AlexandreDecan/portion/blob/2.1.0/CHANGELOG.md)).
  - `python-intervals`: 1.10.0 on 2019-09-26 ([documentation](https://github.com/AlexandreDecan/portion/blob/1.10.0/README.md), [changes](https://github.com/AlexandreDecan/portion/blob/1.10.0/README.md#changelog)).
 
  Note that `python-intervals` will no longer receive updates since it has been replaced by `portion`.
@@ -651,17 +651,17 @@ value is defined:
 ```
 
 The active domain of an `IntervalDict` can be retrieved with its `.domain` method.
-This method always returns a single `Interval` instance, where `.keys` returns a list
-of disjoint intervals, one for each stored value.
+This method always returns a single `Interval` instance, where `.keys` returns
+disjoint intervals, one for each stored value.
 
 ```python
 >>> d.domain()
 [0,4]
->>> d.keys()
+>>> list(d.keys())
 [[0,2), [2,4]]
->>> d.values()
+>>> list(d.values())
 ['banana', 'orange']
->>> d.items()
+>>> list(d.items())
 [([0,2), 'banana'), ([2,4], 'orange')]
 
 ```
@@ -697,6 +697,8 @@ by querying the resulting `IntervalDict` as follows:
 
 Finally, similarly to a `dict`, an `IntervalDict` also supports `len`, `in` and `del`, and defines
 `.clear`, `.copy`, `.update`, `.pop`, `.popitem`, and `.setdefault`.
+For convenience, one can export the content of an `IntervalDict` to a classical Python `dict` using
+the `as_dict` method.
 
 
 [&uparrow; back to top](#table-of-contents)

--- a/portion/dict.py
+++ b/portion/dict.py
@@ -196,20 +196,6 @@ class IntervalDict(MutableMapping):
             i = singleton(i) if not isinstance(i, Interval) else i
             self[i] = v
 
-    def __getitem__(self, key):
-        if isinstance(key, Interval):
-            items = []
-            for i, v in self._items:
-                intersection = key & i
-                if not intersection.empty:
-                    items.append((intersection, v))
-            return IntervalDict(items)
-        else:
-            for i, v in self._items:
-                if key in i:
-                    return v
-            raise KeyError(key)
-
     def combine(self, other, how):
         """
         Return a new IntervalDict that combines the values from current and
@@ -242,6 +228,28 @@ class IntervalDict(MutableMapping):
                     new_items.append((i, v))
 
         return IntervalDict(new_items)
+
+    def as_dict(self):
+        """
+        Return the content as a classical Python dict.
+
+        :return: a Python dict.
+        """
+        return dict(self._items)
+
+    def __getitem__(self, key):
+        if isinstance(key, Interval):
+            items = []
+            for i, v in self._items:
+                intersection = key & i
+                if not intersection.empty:
+                    items.append((intersection, v))
+            return IntervalDict(items)
+        else:
+            for i, v in self._items:
+                if key in i:
+                    return v
+            raise KeyError(key)
 
     def __setitem__(self, key, value):
         interval = key if isinstance(key, Interval) else singleton(key)

--- a/portion/dict.py
+++ b/portion/dict.py
@@ -3,6 +3,8 @@ from .interval import Interval, singleton
 
 from collections.abc import MutableMapping, Mapping
 
+from sortedcontainers import SortedDict
+
 
 def _sort(i):
     return (i[0].lower, i[0].left is Bound.CLOSED, i[0].upper, i[0].right is Bound.OPEN)
@@ -38,7 +40,7 @@ class IntervalDict(MutableMapping):
 
         :param mapping_or_iterable: optional mapping or iterable.
         """
-        self._storage = dict()  # Mapping from intervals to values
+        self._storage = SortedDict(_sort)  # Mapping from intervals to values
 
         if mapping_or_iterable is not None:
             self.update(mapping_or_iterable)
@@ -92,27 +94,33 @@ class IntervalDict(MutableMapping):
 
     def items(self):
         """
-        Return a sorted list of (Interval, value) pairs.
+        Return a set-like object providing a view on contained items.
 
-        :return: a sorted list of 2-uples.
+        Note that currently, the view is not self-updating!
+
+        :return: a set-like object.
         """
-        return sorted(self._storage.items(), key=_sort)
+        return self._storage.items()
 
     def keys(self):
         """
-        Return the list of underlying Interval instances.
+        Return a set-like object providing a view on existing keys.
 
-        :return: a list of intervals.
+        Note that currently, the view is not self-updating!
+
+        :return: a set-like object.
         """
-        return [i for i, v in self.items()]
+        return self._storage.keys()
 
     def values(self):
         """
-        Return the list of values.
+        Return a set-like object providing a view on contained values.
 
-        :return: a list of values.
+        Note that currently, the view is not self-updating!
+
+        :return: a set-like object.
         """
-        return [v for i, v in self.items()]
+        return self._storage.values()
 
     def domain(self):
         """
@@ -272,7 +280,7 @@ class IntervalDict(MutableMapping):
         if not found:
             new_items.append((interval, value))
 
-        self._storage = dict(new_items)
+        self._storage = SortedDict(_sort, new_items)
 
     def __delitem__(self, key):
         interval = key if isinstance(key, Interval) else singleton(key)
@@ -291,7 +299,7 @@ class IntervalDict(MutableMapping):
             else:
                 new_items.append((i, v))
 
-        self._storage = dict(new_items)
+        self._storage = SortedDict(_sort, new_items)
 
         if not found and not isinstance(key, Interval):
             raise KeyError(key)
@@ -314,6 +322,6 @@ class IntervalDict(MutableMapping):
 
     def __eq__(self, other):
         if isinstance(other, IntervalDict):
-            return self.items() == other.items()
+            return self.as_dict() == other.as_dict()
         else:
             return NotImplemented

--- a/portion/dict.py
+++ b/portion/dict.py
@@ -94,25 +94,28 @@ class IntervalDict(MutableMapping):
 
     def items(self):
         """
-        Return a set-like object providing a view on contained items.
+        Return a view object on the contained items sorted by key
+        (see https://docs.python.org/3/library/stdtypes.html#dict-views).
 
-        :return: a set-like object.
+        :return: a view object.
         """
         return self._storage.items()
 
     def keys(self):
         """
-        Return a set-like object providing a view on existing keys.
+        Return a view object on the contained keys (sorted)
+        (see https://docs.python.org/3/library/stdtypes.html#dict-views).
 
-        :return: a set-like object.
+        :return: a view object.
         """
         return self._storage.keys()
 
     def values(self):
         """
-        Return a set-like object providing a view on contained values.
+        Return a view object on the contained values sorted by key
+        (see https://docs.python.org/3/library/stdtypes.html#dict-views).
 
-        :return: a set-like object.
+        :return: a view object.
         """
         return self._storage.values()
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md'), encoding
 
 setup(
     name='portion',
-    version='2.0.2',
+    version='2.1.0',
     license='LGPLv3',
 
     author='Alexandre Decan',
@@ -43,7 +43,9 @@ setup(
     packages=find_packages(include=['portion']),
     python_requires='~=3.5',
 
-    install_requires=[],
+    install_requires=[
+        'sortedcontainers ~= 2.2.2',
+    ],
     extras_require={
         'test': ['pytest ~= 5.0.1'],
         'travis': ['coverage ~= 5.0.3', 'coveralls ~= 1.11.1']

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -109,12 +109,12 @@ class TestIntervalDict:
 
         assert set(d.keys()) == set([P.closedopen(0, 1), P.closedopen(1, 3), P.singleton(3)])
         assert d.domain() == P.closed(0, 3)
-        assert set(d.values()) == set([0, 1, 2])
-        assert set(d.items()) == set([
+        assert set(d.values()) == {0, 1, 2}
+        assert set(d.items()) == {
             (P.closedopen(0, 1), 0),
             (P.closedopen(1, 3), 1),
             (P.singleton(3), 2),
-        ])
+        }
         assert set(d) == set(d.keys())
 
     def test_iterators_on_empty(self):
@@ -122,6 +122,20 @@ class TestIntervalDict:
         assert len(P.IntervalDict().as_dict()) == 0
         assert len(P.IntervalDict().keys()) == 0
         assert P.IntervalDict().domain() == P.empty()
+
+    def test_views(self):
+        d = P.IntervalDict({P.closed(0, 2):3, P.closed(3, 4): 2})
+
+        k, v, i = d.keys(), d.values(), d.items()
+        assert len(k) == len(v) == len(i) == len(d)
+        assert list(k) == [P.closed(0, 2), P.closed(3,4)]
+        assert list(v) == [3, 2]
+        assert list(i) == [(P.closed(0, 2), 3), (P.closed(3, 4), 2)]
+
+        d[5] = 4
+        assert list(k) == list(d.keys())
+        assert list(v) == list(d.values())
+        assert list(i) == list(d.items())
 
     def test_combine_empty(self):
         add = lambda x, y: x + y
@@ -273,17 +287,3 @@ class TestIntervalDict:
         assert d[1] == 'a'
         assert d[2] == 'b'
         assert len(d) == 2
-
-    def test_views(self):
-        d = P.IntervalDict({P.closed(0, 2):3, P.closed(3, 4): 2})
-
-        k, v, i = d.keys(), d.values(), d.items()
-        assert len(k) == len(v) == len(i) == len(d)
-        assert list(k) == [P.closed(0, 2), P.closed(3,4)]
-        assert list(v) == [3, 2]
-        assert list(i) == [(P.closed(0, 2), 3), (P.closed(3, 4), 2)]
-
-        d[5] = 4
-        assert list(k) == list(d.keys())
-        assert list(v) == list(d.values())
-        assert list(i) == list(d.items())

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -18,16 +18,16 @@ class TestIntervalDict:
 
     def test_with_intervals(self):
         d = P.IntervalDict([(P.closed(0, 2), 0)])
-        assert d[P.open(-P.inf, P.inf)].items() == [(P.closed(0, 2), 0)]
-        assert d[P.closed(0, 2)].items() == [(P.closed(0, 2), 0)]
-        assert d[P.closed(-1, 0)].items() == [(P.singleton(0), 0)]
-        assert d[P.closed(-2, -1)].items() == []
-        assert d.get(P.closed(0, 2)).items() == [(P.closed(0, 2), 0)]
-        assert d.get(P.closed(-2, -1)).items() == [(P.closed(-2, -1), None)]
-        assert d.get(P.closed(-1, 0)).items() == [(P.closedopen(-1, 0), None), (P.singleton(0), 0)]
+        assert d[P.open(-P.inf, P.inf)].as_dict() == {P.closed(0, 2): 0}
+        assert d[P.closed(0, 2)].as_dict() == {P.closed(0, 2): 0}
+        assert d[P.closed(-1, 0)].as_dict() == {P.singleton(0): 0}
+        assert d[P.closed(-2, -1)].as_dict() == {}
+        assert d.get(P.closed(0, 2)).as_dict() == {P.closed(0, 2): 0}
+        assert d.get(P.closed(-2, -1)).as_dict() == {P.closed(-2, -1): None}
+        assert d.get(P.closed(-1, 0)).as_dict() == {P.closedopen(-1, 0): None, P.singleton(0): 0}
 
         d[P.closed(1, 3)] = 1
-        assert d.items() == [(P.closedopen(0, 1), 0), (P.closed(1, 3), 1)]
+        assert d.as_dict() == {P.closedopen(0, 1): 0, P.closed(1, 3): 1}
         assert len(d) == 2
         assert d[0] == 0
         assert d.get(0, -1) == 0
@@ -43,19 +43,19 @@ class TestIntervalDict:
         # Set values
         d = P.IntervalDict([(P.closed(0, 2), 0)])
         d[3] = 2
-        assert d.items() == [(P.closed(0, 2), 0), (P.singleton(3), 2)]
+        assert d.as_dict() == {P.closed(0, 2): 0, P.singleton(3): 2}
         d[3] = 3
-        assert d.items() == [(P.closed(0, 2), 0), (P.singleton(3), 3)]
+        assert d.as_dict() == {P.closed(0, 2): 0, P.singleton(3): 3}
         d[P.closed(0, 2)] = 1
-        assert d.items() == [(P.closed(0, 2), 1), (P.singleton(3), 3)]
+        assert d.as_dict() == {P.closed(0, 2): 1, P.singleton(3): 3}
         d[P.closed(-1, 1)] = 2
-        assert d.items() == [(P.closed(-1, 1), 2), (P.openclosed(1, 2), 1), (P.singleton(3), 3)]
+        assert d.as_dict() == {P.closed(-1, 1): 2, P.openclosed(1, 2): 1, P.singleton(3): 3}
 
         d = P.IntervalDict([(P.closed(0, 2), 0)])
         d[P.closed(-1, 4)] = 1
-        assert d.items() == [(P.closed(-1, 4), 1)]
+        assert d.as_dict() == {P.closed(-1, 4): 1}
         d[P.closed(5, 6)] = 1
-        assert d.items() == [(P.closed(-1, 4) | P.closed(5, 6), 1)]
+        assert d.as_dict() == {P.closed(-1, 4) | P.closed(5, 6): 1}
 
     def test_delete_value(self):
         d = P.IntervalDict([(P.closed(0, 2), 0)])
@@ -74,17 +74,17 @@ class TestIntervalDict:
     def test_delete_interval(self):
         d = P.IntervalDict([(P.closed(0, 2), 0)])
         del d[P.closed(-1, 1)]
-        assert d.items() == [(P.openclosed(1, 2), 0)]
+        assert d.as_dict() == {P.openclosed(1, 2): 0}
 
     def test_delete_interval_out_of_bound(self):
         d = P.IntervalDict([(P.closed(0, 2), 0)])
         del d[P.closed(-10, -9)]
-        assert d.items() == [(P.closed(0, 2), 0)]
+        assert d.as_dict() == {P.closed(0, 2): 0}
 
     def test_delete_empty_interval(self):
         d = P.IntervalDict([(P.closed(0, 2), 0)])
         del d[P.empty()]
-        assert d.items() == [(P.closed(0, 2), 0)]
+        assert d.as_dict() == {P.closed(0, 2): 0}
 
     def test_setdefault_with_values(self):
         d = P.IntervalDict([(P.closed(0, 2), 0)])
@@ -96,27 +96,31 @@ class TestIntervalDict:
     def test_setdefault_with_intervals(self):
         d = P.IntervalDict([(P.closed(0, 2), 0)])
         t = d.setdefault(P.closed(-2, -1), -1)
-        assert t.items() == [(P.closed(-2, -1), -1)]
-        assert d.items() == [(P.closed(-2, -1), -1), (P.closed(0, 2), 0)]
+        assert t.as_dict() == {P.closed(-2, -1): -1}
+        assert d.as_dict() == {P.closed(-2, -1): -1, P.closed(0, 2): 0}
 
         d = P.IntervalDict([(P.closed(0, 2), 0)])
         t = d.setdefault(P.closed(-1, 1), 2)
-        assert t.items() == [(P.closedopen(-1, 0), 2), (P.closed(0, 1), 0)]
-        assert d.items() == [(P.closedopen(-1, 0), 2), (P.closed(0, 2), 0)]
+        assert t.as_dict() == {P.closedopen(-1, 0): 2, P.closed(0, 1): 0}
+        assert d.as_dict() == {P.closedopen(-1, 0): 2, P.closed(0, 2): 0}
 
     def test_iterators(self):
         d = P.IntervalDict([(P.closedopen(0, 1), 0), (P.closedopen(1, 3), 1), (P.singleton(3), 2)])
 
-        assert d.keys() == [P.closedopen(0, 1), P.closedopen(1, 3), P.singleton(3)]
+        assert set(d.keys()) == set([P.closedopen(0, 1), P.closedopen(1, 3), P.singleton(3)])
         assert d.domain() == P.closed(0, 3)
-        assert d.values() == [0, 1, 2]
-        assert d.items() == list(zip(d.keys(), d.values()))
-        assert list(d) == d.keys()
+        assert set(d.values()) == set([0, 1, 2])
+        assert set(d.items()) == set([
+            (P.closedopen(0, 1), 0),
+            (P.closedopen(1, 3), 1),
+            (P.singleton(3), 2),
+        ])
+        assert set(d) == set(d.keys())
 
     def test_iterators_on_empty(self):
-        assert P.IntervalDict().values() == []
-        assert P.IntervalDict().items() == []
-        assert P.IntervalDict().keys() == []
+        assert len(P.IntervalDict().values()) == 0
+        assert len(P.IntervalDict().as_dict()) == 0
+        assert len(P.IntervalDict().keys()) == 0
         assert P.IntervalDict().domain() == P.empty()
 
     def test_combine_empty(self):
@@ -186,17 +190,17 @@ class TestIntervalDict:
     def test_pop_interval(self):
         d = P.IntervalDict([(P.closed(0, 3), 0)])
         t = d.pop(P.closed(0, 1))
-        assert t.items() == [(P.closed(0, 1), 0)]
-        assert d.items() == [(P.openclosed(1, 3), 0)]
+        assert t.as_dict() == {P.closed(0, 1): 0}
+        assert d.as_dict() == {P.openclosed(1, 3): 0}
 
         t = d.pop(P.closed(0, 2), 1)
-        assert t.items() == [(P.closed(0, 1), 1), (P.openclosed(1, 2), 0)]
-        assert d.items() == [(P.openclosed(2, 3), 0)]
+        assert t.as_dict() == {P.closed(0, 1): 1, P.openclosed(1, 2): 0}
+        assert d.as_dict() == {P.openclosed(2, 3): 0}
 
     def test_popitem(self):
         d = P.IntervalDict([(P.closed(0, 3), 0)])
         t = d.popitem()
-        assert t.items() == [(P.closed(0, 3), 0)]
+        assert t.as_dict() == {P.closed(0, 3): 0}
         assert len(d) == 0
 
     def test_popitem_with_empty(self):
@@ -235,7 +239,7 @@ class TestIntervalDict:
         assert a != d
         assert a == b
         assert a != 1
-        assert a.items() == [(P.closed(-1, 1), 2), (P.openclosed(1, 2), 0), (P.closed(4, 5), 1)]
+        assert a.as_dict() == {P.closed(-1, 1): 2, P.openclosed(1, 2): 0, P.closed(4, 5): 1}
 
         assert P.IntervalDict([(0, 0), (1, 1)]) == P.IntervalDict([(1, 1), (0, 0)])
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -107,7 +107,7 @@ class TestIntervalDict:
     def test_iterators(self):
         d = P.IntervalDict([(P.closedopen(0, 1), 0), (P.closedopen(1, 3), 1), (P.singleton(3), 2)])
 
-        assert set(d.keys()) == set([P.closedopen(0, 1), P.closedopen(1, 3), P.singleton(3)])
+        assert set(d.keys()) == {P.closedopen(0, 1), P.closedopen(1, 3), P.singleton(3)}
         assert d.domain() == P.closed(0, 3)
         assert set(d.values()) == {0, 1, 2}
         assert set(d.items()) == {

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -200,7 +200,7 @@ class TestIntervalDict:
     def test_popitem(self):
         d = P.IntervalDict([(P.closed(0, 3), 0)])
         t = d.popitem()
-        assert t.as_dict() == {P.closed(0, 3): 0}
+        assert t == (P.closed(0, 3), 0)
         assert len(d) == 0
 
     def test_popitem_with_empty(self):

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -273,3 +273,17 @@ class TestIntervalDict:
         assert d[1] == 'a'
         assert d[2] == 'b'
         assert len(d) == 2
+
+    def test_views(self):
+        d = P.IntervalDict({P.closed(0, 2):3, P.closed(3, 4): 2})
+
+        k, v, i = d.keys(), d.values(), d.items()
+        assert len(k) == len(v) == len(i) == len(d)
+        assert list(k) == [P.closed(0, 2), P.closed(3,4)]
+        assert list(v) == [3, 2]
+        assert list(i) == [(P.closed(0, 2), 3), (P.closed(3, 4), 2)]
+
+        d[5] = 4
+        assert list(k) == list(d.keys())
+        assert list(v) == list(d.values())
+        assert list(i) == list(d.items())


### PR DESCRIPTION
This pull request addresses #34. 

It also slightly improves the performance when adding,  updating or removing an item since `IntervalDict` does not longer require an in-memory copy of its internal storage to be duplicated for these operations. 

This PR also fixes an issue with `popitem` and the documentation of `pop`. 