### PR TITLE
support to_data\from_data for DictInterval

### DIFF
--- a/portion/__init__.py
+++ b/portion/__init__.py
@@ -1,7 +1,7 @@
 from .const import Bound, inf
 from .interval import Interval, open, closed, openclosed, closedopen, empty, singleton
 from .func import iterate
-from .io import from_string, to_string, from_data, to_data
+from .io import from_string, to_string, from_data, to_data, dict_to_data, dict_from_data
 from .dict import IntervalDict
 
 
@@ -10,7 +10,7 @@ __all__ = [
     'Interval',
     'open', 'closed', 'openclosed', 'closedopen', 'singleton', 'empty',
     'iterate',
-    'from_string', 'to_string', 'from_data', 'to_data',
+    'from_string', 'to_string', 'from_data', 'to_data', 'dict_to_data', 'dict_from_data',
     'IntervalDict',
 ]
 

--- a/portion/io.py
+++ b/portion/io.py
@@ -2,6 +2,7 @@ import re
 
 from .const import Bound, inf
 from .interval import Interval
+from .dict import IntervalDict
 
 
 def from_string(string, conv, *, bound=r'.+?', disj=r' ?\| ?', sep=r', ?',
@@ -171,7 +172,7 @@ def to_data(interval, conv=None, *, pinf=float('inf'), ninf=float('-inf')):
         ))
     return data
 
-def dict_to_data(interval, conv=None, *, pinf=float('inf'), ninf=float('-inf')):
+def dict_to_data(interval, conv=None, conv_data=None, *, pinf=float('inf'), ninf=float('-inf')):
     """
     Export given DictInteval to a list of 2-uples ((left, lower,upper, right), item)
 
@@ -188,9 +189,9 @@ def dict_to_data(interval, conv=None, *, pinf=float('inf'), ninf=float('-inf')):
     data = []
 
     def _convert(bound):
-        if bound == portion.inf:
+        if bound == inf:
             return pinf
-        elif bound == -portion.inf:
+        elif bound == -inf:
             return ninf
         else:
             return conv(bound)
@@ -224,19 +225,19 @@ def dict_from_data(data, conv=None, conv_data=None, *, pinf=float('inf'), ninf=f
 
     def _convert(bound):
         if bound == pinf:
-            return portion.inf
+            return inf
         elif bound == ninf:
-            return -portion.inf
+            return -inf
         else:
             return conv(bound)
 
-    ret = portion.IntervalDict()
+    ret = IntervalDict()
     for (left, lower, upper, right), value in data:
-        interval = portion.Interval.from_atomic(
-            portion.Bound(left),
+        interval = Interval.from_atomic(
+            Bound(left),
             _convert(lower),
             _convert(upper),
-            portion.Bound(right),
+            Bound(right),
         )
         ret[interval] = conv_data(value)
     return ret

--- a/portion/io.py
+++ b/portion/io.py
@@ -1,7 +1,7 @@
 import re
 
 from .const import Bound, inf
-from .interval import Interval
+from .interval import Interval, empty
 from .dict import IntervalDict
 
 
@@ -176,35 +176,18 @@ def dict_to_data(interval, conv=None, conv_data=None, *, pinf=float('inf'), ninf
     """
     Export given DictInteval to a list of 2-uples ((left, lower,upper, right), item)
 
-    :param interval: an DictInteval.
+    :param interval: an DictInterval.
     :param conv: function that convert bounds to "lower" and "upper", default to identity.
     :param conv_data: function that convert value, default to identity.
     :param pinf: value used to encode positive infinity.
     :param ninf: value used to encode negative infinity.
     :return: a list of 4-uples (left, lower, upper, right)
     """
-    conv = (lambda v: v) if conv is None else conv
     conv_data = (lambda v: v) if conv_data is None else conv_data
-
-    data = []
-
-    def _convert(bound):
-        if bound == inf:
-            return pinf
-        elif bound == -inf:
-            return ninf
-        else:
-            return conv(bound)
-
-    for key, value in interval.items():
-        data.append((
-          (
-              key.left.value,
-              _convert(key.lower),
-              _convert(key.upper),
-              key.right.value,
-          ), conv_data(value))
-        )
+    data = {
+        tuple(to_data(key, conv, pinf=pinf, ninf=ninf)): conv_data(value)
+        for key, value in interval.items()
+    }
     return data
 
 
@@ -219,25 +202,10 @@ def dict_from_data(data, conv=None, conv_data=None, *, pinf=float('inf'), ninf=f
     :param ninf: value used to represent negative infinity.
     :return: an Interval instance.
     """
-    intervals = []
-    conv = (lambda v: v) if conv is None else conv
     conv_data = (lambda v: v) if conv_data is None else conv_data
+    interval = IntervalDict({
+        from_data(key, conv=conv, pinf=pinf, ninf=ninf): conv_data(value)
+        for key, value in data.items()
+    })
+    return interval
 
-    def _convert(bound):
-        if bound == pinf:
-            return inf
-        elif bound == ninf:
-            return -inf
-        else:
-            return conv(bound)
-
-    ret = IntervalDict()
-    for (left, lower, upper, right), value in data:
-        interval = Interval.from_atomic(
-            Bound(left),
-            _convert(lower),
-            _convert(upper),
-            Bound(right),
-        )
-        ret[interval] = conv_data(value)
-    return ret


### PR DESCRIPTION
I suppose to "serialize" DictIntevals to the list of 2-tuples  `( (left, lower, upper,right), item )`.