### PR TITLE
Ease subclassing `Interval`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,16 @@
 repos:
   - repo: local
     hooks:
-      - id: install
-        name: install package
-        entry: poetry install
+      - id: black
+        name: check code style
+        entry: poetry run black --check
         language: python
-        always_run: true
-        pass_filenames: false
+        pass_filenames: true
+        types: ["python"]
       - id: pytest
         name: run test suite
         entry: poetry run pytest
         language: python
         always_run: true
         pass_filenames: false
-      - id: black
-        name: check code style
-        entry: poetry run black --check portion
-        language: python
-        pass_filenames: false
-        always_run: true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 
 ### Changed
  - Use `poetry` instead of `setuptools` to build `portion`.
-
+ - Some internal changes to ease subclassing `Interval`(see [#58](https://github.com/AlexandreDecan/58)):
+   * Use `self.__class__` instead of `Interval` to create new instances;
+   * Deprecate and move `mergeable` function to `Interval._mergeable` class method;
+   * `Interval.from_atomic` is now a class method instead of a static method.
 
 
 ## 2.1.6 (2021-04-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changed
  - Use `poetry` instead of `setuptools` to build `portion`.
- - Some internal changes to ease subclassing `Interval`(see [#58](https://github.com/AlexandreDecan/58)):
+ - Some internal changes to ease subclassing `Interval`(see [#58](https://github.com/AlexandreDecan/issues/58)):
    * Use `self.__class__` instead of `Interval` to create new instances;
    * Deprecate and move `mergeable` function to `Interval._mergeable` class method;
    * `Interval.from_atomic` is now a class method instead of a static method.

--- a/portion/interval.py
+++ b/portion/interval.py
@@ -227,8 +227,8 @@ class Interval:
         """
         return len(self._intervals) == 1
 
-    @staticmethod
-    def from_atomic(left, lower, upper, right):
+    @classmethod
+    def from_atomic(cls, left, lower, upper, right):
         """
         Create an Interval instance containing a single atomic interval.
 
@@ -237,13 +237,13 @@ class Interval:
         :param upper: value of the upper bound.
         :param right: either CLOSED or OPEN.
         """
-        instance = Interval()
+        instance = cls()
         left = left if lower not in [inf, -inf] else Bound.OPEN
         right = right if upper not in [inf, -inf] else Bound.OPEN
 
         instance._intervals = [Atomic(left, lower, upper, right)]
         if instance.empty:
-            return Interval()
+            return cls()
 
         return instance
 

--- a/portion/interval.py
+++ b/portion/interval.py
@@ -1,3 +1,5 @@
+import warnings
+
 from collections import namedtuple
 from .const import Bound, inf
 
@@ -14,15 +16,11 @@ def mergeable(a, b):
     :param b: an atomic interval.
     :return: True if mergeable, False otherwise.
     """
-    if a.lower < b.lower or (a.lower == b.lower and a.left == Bound.CLOSED):
-        first, second = a, b
-    else:
-        first, second = b, a
-
-    if first.upper == second.lower:
-        return first.right == Bound.CLOSED or second.left == Bound.CLOSED
-
-    return first.upper > second.lower
+    warnings.warn(
+        "This function is deprecated, use Interval._mergeable instead.",
+        DeprecationWarning,
+    )
+    return Interval._mergeable(a, b)
 
 
 def open(lower, upper):
@@ -128,7 +126,7 @@ class Interval:
                 current = self._intervals[i]
                 successor = self._intervals[i + 1]
 
-                if mergeable(current, successor):
+                if self.__class__._mergeable(current, successor):
                     if current.lower == successor.lower:
                         lower = current.lower
                         left = (
@@ -161,6 +159,26 @@ class Interval:
                     self._intervals.insert(i, union)
                 else:
                     i = i + 1
+
+    @classmethod
+    def _mergeable(cls, a, b):
+        """
+        Tester whether two atomic intervals can be merged (i.e. they overlap or
+        are adjacent).
+
+        :param a: an atomic interval.
+        :param b: an atomic interval.
+        :return: True if mergeable, False otherwise.
+        """
+        if a.lower < b.lower or (a.lower == b.lower and a.left == Bound.CLOSED):
+            first, second = a, b
+        else:
+            first, second = b, a
+
+        if first.upper == second.lower:
+            return first.right == Bound.CLOSED or second.left == Bound.CLOSED
+
+        return first.upper > second.lower
 
     @property
     def left(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
-include = ["CHANGELOG.md", "LICENSE.txt", "tests/"]
+include = ["README.md", "CHANGELOG.md", "LICENSE.txt", "tests/"]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
This PR implements the changes asked in #58 : 
 - Use `self.__class__` instead of `Interval` to create new instances; 
 - Convert `from_atomic` to a class method so that we create instances of the current class; 
 - Move `mergeable` to the `_mergeable` class method so that it can be overridden. 

@xguse Can you have a look at these changes and see if I forgot something? ;-) 