### PR TITLE
Use SortedDict feature to pre-filter intervals we cannot overlap with

### DIFF
--- a/portion/dict.py
+++ b/portion/dict.py
@@ -260,11 +260,14 @@ class IntervalDict(MutableMapping):
 
     def __getitem__(self, key):
         if isinstance(key, Interval):
+            # No need to consider intervals with left boundary > key.upper
+            max_key = (key.upper, True)
+
             items = []
-            for i, v in self._storage.items():
+            for i in self._storage.irange_key(max_key=max_key):
                 intersection = key & i
                 if not intersection.empty:
-                    items.append((intersection, v))
+                    items.append((intersection, self._storage[i]))
             return IntervalDict._from_items(items)
         else:
             for i, v in self._storage.items():


### PR DESCRIPTION
SortedDict provides irange_key() which allows us to consider a smaller number of stored intervals for intersection, if desired. Because the intervals are sorted by the lower boundary, intervals above the right
boundary of our search key can be excluded from search.

I have a large IntervalDict I must search repeatedly, and this provides roughly a 2X speedup.