### PR TITLE
Early out for non-overlapping intervals in __and__

### DIFF
--- a/portion/interval.py
+++ b/portion/interval.py
@@ -466,7 +466,11 @@ class Interval:
         if not isinstance(other, Interval):
             return NotImplemented
 
-        if self.atomic and other.atomic:
+        if (self.upper < other.lower) or (self.lower > other.upper):
+            # early out for non-overlapping intervals
+            intersections = []
+            return self.__class__(*intersections)
+        elif self.atomic and other.atomic:
             if self.lower == other.lower:
                 lower = self.lower
                 left = self.left if self.left == Bound.OPEN else other.left


### PR DESCRIPTION
In cases where intervals are frequently compared against other
intervals they do not intersect with, a lot of unnecessary work is
done. This adds a shortcut for that case.

In my use case this produces roughly a 9X speedup.