### PR TITLE
Add `missing` parameter in `combine`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 
-## Next release
+## Next release (2.5.0)
+
+### Added
+ - The `combine` method of an `IntervalDict` accepts a `missing` parameter to fill values for non-overlapping keys (see [#95](https://github.com/AlexandreDecan/portion/issues/95)).
 
 ### Changed
  - Drop official support for Python 3.7.
@@ -11,7 +14,7 @@
 ## 2.4.2 (2023-12-06)
 
 ### Fixed
- - Import error when using `create_api` in Python 3.10+ (see [#87](https://github.com/AlexandreDecan/portion/issues/85)).
+ - Import error when using `create_api` in Python 3.10+ (see [#87](https://github.com/AlexandreDecan/portion/issues/87)).
 
 
 

--- a/README.md
+++ b/README.md
@@ -697,9 +697,11 @@ See [#44](https://github.com/AlexandreDecan/portion/issues/44#issuecomment-71019
 
 Two `IntervalDict` instances can be combined together using the `.combine` method.
 This method returns a new `IntervalDict` whose keys and values are taken from the two
-source `IntervalDict`. Values corresponding to non-intersecting keys are simply copied,
-while values corresponding to intersecting keys are combined together using the provided
-function, as illustrated hereafter:
+source `IntervalDict`.
+The values corresponding to intersecting keys (i.e., when the two instances overlap)
+are combined using the provided `how` function, while values corresponding to
+non-intersecting keys are simply copied (i.e., the `how` function is not called
+for them), as illustrated hereafter:
 
 ```python
 >>> d1 = P.IntervalDict({P.closed(0, 2): 'banana'})
@@ -707,6 +709,16 @@ function, as illustrated hereafter:
 >>> concat = lambda x, y: x + '/' + y
 >>> d1.combine(d2, how=concat)
 {[0,1): 'banana', [1,2]: 'banana/orange', (2,3]: 'orange'}
+
+```
+
+The `combine` method also accepts a `missing` parameter. When `missing` is set,
+the `how` function is called even for non-intersecting keys, using the value of
+`missing` to replace the missing values:
+
+```python
+>>> d1.combine(d2, how=concat, missing='kiwi')
+{[0,1): 'banana/kiwi', [1,2]: 'banana/orange', (2,3]: 'kiwi/orange'}
 
 ```
 
@@ -723,6 +735,8 @@ by querying the resulting `IntervalDict` as follows:
 {[1,2]: 'banana/orange'}
 
 ```
+
+
 
 Finally, similarly to a `dict`, an `IntervalDict` also supports `len`, `in` and `del`, and defines
 `.clear`, `.copy`, `.update`, `.pop`, `.popitem`, and `.setdefault`.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(
 
 setup(
     name="portion",
-    version="2.4.2",
+    version="2.5.0",
     license="LGPLv3",
     author="Alexandre Decan",
     url="https://github.com/AlexandreDecan/portion",

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -152,6 +152,7 @@ class TestIntervalDict:
 
     def test_combine_nonempty(self):
         def add(x, y): return x + y
+
         d1 = P.IntervalDict([(P.closed(1, 3) | P.closed(5, 7), 1)])
         d2 = P.IntervalDict([(P.closed(2, 4) | P.closed(6, 8), 2)])
         assert d1.combine(d2, add) == d2.combine(d1, add)
@@ -179,6 +180,31 @@ class TestIntervalDict:
             P.singleton(4): 3,
             P.openclosed(4, 5): 1,
         })
+
+    def test_combine_missing(self):
+        def how(x, y): return x, y
+
+        d1 = P.IntervalDict([(P.closed(1, 3), 1)])
+        d2 = P.IntervalDict([(P.closed(2, 4), 2)])
+        assert d1.combine(d2, how=how, missing=None) == P.IntervalDict([
+            (P.closedopen(1, 2), (1, None)),
+            (P.closed(2, 3), (1, 2)),
+            (P.openclosed(3, 4), (None, 2))
+        ])
+
+        assert d2.combine(d1, how=how, missing=None) == P.IntervalDict([
+            (P.closedopen(1, 2), (None, 1)),
+            (P.closed(2, 3), (2, 1)),
+            (P.openclosed(3, 4), (2, None))
+        ])
+
+        def add(x, y): return x + y
+        assert d2.combine(d1, how=add, missing=3) == P.IntervalDict([
+            (P.closedopen(1, 2), 4),
+            (P.closed(2, 3), 3),
+            (P.openclosed(3, 4), 5)
+        ])
+
 
     def test_containment(self):
         d = P.IntervalDict([(P.closed(0, 3), 0)])


### PR DESCRIPTION
Extend the `.combine` method of an `IntervalDict` with a `missing` parameter. Its value, when set, replaces the values that are missing in one of the two `IntervalDict` instances when calling the `how` function. This is, the `how` function will be called, even for non-overlapping keys. 

Taking the example from the documentation: 

```python
>>> d1 = P.IntervalDict({P.closed(0, 2): 'banana'})
>>> d2 = P.IntervalDict({P.closed(1, 3): 'orange'})
>>> concat = lambda x, y: x + '/' + y
>>> d1.combine(d2, how=concat)
{[0,1): 'banana', [1,2]: 'banana/orange', (2,3]: 'orange'}
>>> d1.combine(d2, how=concat, missing='kiwi')
{[0,1): 'banana/kiwi', [1,2]: 'banana/orange', (2,3]: 'kiwi/orange'}

```

This doesn't solve #95 yet but is a first step in that direction. @marcsarrel could you please have a look at this change? 